### PR TITLE
Improves Model.sample(1) case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 - 2016.05.07
+
+- Improves `Model.sample(1)` case.
+
 ## 1.0.0 - 2016.05.05
 
 - Initial release :tada:.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Sample functionality for Active Record.
 
 ## Usage
 
+**Don't use this for large set of data for now (See [#1](https://github.com/JuanitoFatas/active_sample/issues/1)).**
+
 ```ruby
 User.count # => 0
 User.sample => nil

--- a/lib/active_sample.rb
+++ b/lib/active_sample.rb
@@ -10,16 +10,18 @@ module ActiveSample
       raise NegativeSampleError.new("negative sample number".freeze)
     end
 
-    return nil if count == 0
+    max_id = maximum(:id)
 
-    if n > count
-      where(id: ids.shuffle)
-    elsif n > 1
-      where(id: ids.sample(n))
+    return nil if max_id == nil
+
+    if n == 1
+      while !(found = find_by(id: 1 + rand(max_id))); end
+
+      found
     elsif n == 0
-      where(id: [])
+      none
     else
-      find ids.sample
+      where(id: ids.sample(n))
     end
   end
 end

--- a/lib/active_sample/version.rb
+++ b/lib/active_sample/version.rb
@@ -1,3 +1,3 @@
 module ActiveSample
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Randomly pick record from `[1..max)` to avoid loading `ids` into memory.

For `sample(n)`:

I need to implement [this (PostgreSQL only)](http://stackoverflow.com/a/8675160/517868).

related: #1.
